### PR TITLE
Fix LWWRegister join with nil clocks

### DIFF
--- a/lib/loom/lwwregister.ex
+++ b/lib/loom/lwwregister.ex
@@ -101,8 +101,8 @@ defmodule Loom.LWWRegister do
   """
   @spec join(t, t) :: t
   def join(a, a), do: a
-  def join(a, %Reg{clock: nil}=b), do: a
-  def join(%Reg{clock: nil}=a, b), do: b
+  def join(a, %Reg{clock: nil}), do: a
+  def join(%Reg{clock: nil}, b), do: b
   def join(%Reg{clock: c}=a, %Reg{clock: c}=b) do
     if a > b, do: a, else: b
   end

--- a/lib/loom/lwwregister.ex
+++ b/lib/loom/lwwregister.ex
@@ -101,6 +101,8 @@ defmodule Loom.LWWRegister do
   """
   @spec join(t, t) :: t
   def join(a, a), do: a
+  def join(a, %Reg{clock: nil}=b), do: a
+  def join(%Reg{clock: nil}=a, b), do: b
   def join(%Reg{clock: c}=a, %Reg{clock: c}=b) do
     if a > b, do: a, else: b
   end

--- a/test/loom_lwwregister_test.exs
+++ b/test/loom_lwwregister_test.exs
@@ -41,6 +41,8 @@ defmodule LoomLwwregisterTest do
     a = Reg.new("a")
     b = Reg.new("b", nil)
     ab_value = a |> Reg.join(b) |> Reg.value
+    ba_value = b |> Reg.join(a) |> Reg.value
     assert "a" == ab_value
+    assert "a" == ba_value
   end
 end

--- a/test/loom_lwwregister_test.exs
+++ b/test/loom_lwwregister_test.exs
@@ -1,7 +1,48 @@
 defmodule LoomLwwregisterTest do
   use ExUnit.Case
+  alias Loom.LWWRegister, as: Reg
 
   doctest Loom.LWWRegister
   doctest Loom.CRDT.Loom.LWWRegister # The Protocol implementation
 
+  test "Basic value setting" do
+    reg = Reg.new |> Reg.set("test")
+    assert "test" == reg |> Reg.value
+  end
+
+  describe "Join" do
+    test "with default clock" do
+      a = Reg.new("a")
+      b = Reg.new("b")
+      ab_value = a |> Reg.join(b) |> Reg.value
+      assert "b" == ab_value
+    end
+
+    test "with explicit clocks" do
+      a = Reg.new("a", 2)
+      b = Reg.new("b", 1)
+      ab_value = a |> Reg.join(b) |> Reg.value
+      assert "a" == ab_value
+    end
+
+    test "with equal crdt" do
+      a = Reg.new("a")
+      value = a |> Reg.join(a) |> Reg.value
+      assert "a" == value
+    end
+
+    test "with equal clocks" do
+      a = Reg.new("a", 1)
+      b = Reg.new("b", 1)
+      ab_value = a |> Reg.join(b) |> Reg.value
+      assert "b" == ab_value
+    end
+
+    test "with nil clock" do
+      a = Reg.new("a")
+      b = Reg.new("b", nil)
+      ab_value = a |> Reg.join(b) |> Reg.value
+      assert "a" == ab_value
+    end
+  end
 end

--- a/test/loom_lwwregister_test.exs
+++ b/test/loom_lwwregister_test.exs
@@ -10,39 +10,37 @@ defmodule LoomLwwregisterTest do
     assert "test" == reg |> Reg.value
   end
 
-  describe "Join" do
-    test "with default clock" do
-      a = Reg.new("a")
-      b = Reg.new("b")
-      ab_value = a |> Reg.join(b) |> Reg.value
-      assert "b" == ab_value
-    end
+  test "Join with default clock" do
+    a = Reg.new("a")
+    b = Reg.new("b")
+    ab_value = a |> Reg.join(b) |> Reg.value
+    assert "b" == ab_value
+  end
 
-    test "with explicit clocks" do
-      a = Reg.new("a", 2)
-      b = Reg.new("b", 1)
-      ab_value = a |> Reg.join(b) |> Reg.value
-      assert "a" == ab_value
-    end
+  test "Join with explicit clocks" do
+    a = Reg.new("a", 2)
+    b = Reg.new("b", 1)
+    ab_value = a |> Reg.join(b) |> Reg.value
+    assert "a" == ab_value
+  end
 
-    test "with equal crdt" do
-      a = Reg.new("a")
-      value = a |> Reg.join(a) |> Reg.value
-      assert "a" == value
-    end
+  test "Join with equal crdt" do
+    a = Reg.new("a")
+    value = a |> Reg.join(a) |> Reg.value
+    assert "a" == value
+  end
 
-    test "with equal clocks" do
-      a = Reg.new("a", 1)
-      b = Reg.new("b", 1)
-      ab_value = a |> Reg.join(b) |> Reg.value
-      assert "b" == ab_value
-    end
+  test "Join with equal clocks" do
+    a = Reg.new("a", 1)
+    b = Reg.new("b", 1)
+    ab_value = a |> Reg.join(b) |> Reg.value
+    assert "b" == ab_value
+  end
 
-    test "with nil clock" do
-      a = Reg.new("a")
-      b = Reg.new("b", nil)
-      ab_value = a |> Reg.join(b) |> Reg.value
-      assert "a" == ab_value
-    end
+  test "Join with nil clock" do
+    a = Reg.new("a")
+    b = Reg.new("b", nil)
+    ab_value = a |> Reg.join(b) |> Reg.value
+    assert "a" == ab_value
   end
 end


### PR DESCRIPTION
Consider the following:

```elixir
alias Loom.AWORMap, as: KVSet
alias Loom.LWWRegister, as: Reg

reg = Reg.new("test")
kvset = KVSet.new |> KVSet.put(:a, :key, reg)
KVSet.get(kvset, :key, Reg) # returns %Loom.LWWRegister{clock: nil, value: nil}
```

This happens because the `LWWRegister` join function considers `a.clock > b.clock` when `a.clock` is `nil`. To avoid that, if either argument has a `nil` clock, the other is returned.