### PR TITLE
Fix warning in Elixir 1.4

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,10 +4,10 @@ defmodule Loom.Mixfile do
   def project do
     [app: :loom,
      description: "A modern CRDT library that uses protocols to create composable CRDTs.",
-     package: package,
+     package: package(),
      version: "0.1.0-dev",
      elixir: "~> 1.0",
-     deps: deps,
+     deps: deps(),
      test_coverage: [tool: ExCoveralls],
     #  docs: [readme: true, main: "README"]
     ]


### PR DESCRIPTION
Since Elixir 1.4, there are warnings for invoking functions with no arguments, without parenthesis.

Especially in Phoenix, the following warning would constantly show up:

```
warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  /app/deps/loom/mix.exs:7

warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  /app/deps/loom/mix.exs:10
```

Adding the parenthesis in `mix.exs` fixes the warning.