### PR TITLE
Fix compile-time warnings

### DIFF
--- a/lib/loom/awormap.ex
+++ b/lib/loom/awormap.ex
@@ -174,10 +174,10 @@ defmodule Loom.AWORMap do
   @spec value(t) :: [{key,term}] | nil
   def value(%M{dots: d}) do
     res = Enum.reduce(Dots.dots(d), %{}, fn {_, {k, %{__struct__: module}=crdt}}, values ->
-            Dict.update(values, {k, module}, crdt, &CRDT.join(crdt,&1))
+            Map.update(values, {k, module}, crdt, &CRDT.join(crdt,&1))
           end)
           |> Enum.map(fn {k,v} -> {k, CRDT.value(v)} end)
-          |> Enum.into %{}
+          |> Enum.into(%{})
     case map_size(res) do
       0 -> nil
       _ -> res

--- a/lib/loom/gcounter.ex
+++ b/lib/loom/gcounter.ex
@@ -46,7 +46,7 @@ defmodule Loom.GCounter do
   """
   @spec new([values: [{actor, pos_integer}]]) :: t
   def new(opts) do
-    new_values = Keyword.get(opts, :values, []) |> Enum.into %{}
+    new_values = Keyword.get(opts, :values, []) |> Enum.into(%{})
     %Counter{counter: new_values}
   end
 
@@ -71,7 +71,7 @@ defmodule Loom.GCounter do
   """
   @spec value(t) :: non_neg_integer
   def value(%Counter{counter: c}) do
-    Dict.values(c) |> Enum.sum
+    Map.values(c) |> Enum.sum
   end
 
   @doc """
@@ -88,7 +88,7 @@ defmodule Loom.GCounter do
   """
   @spec join(t, t) :: t
   def join(%Counter{counter: c1}, %Counter{counter: c2}) do
-    %Counter{counter: Dict.merge(c1, c2, fn (_,v1,v2) -> max(v1,v2) end)}
+    %Counter{counter: Map.merge(c1, c2, fn (_,v1,v2) -> max(v1,v2) end)}
   end
 
 end

--- a/lib/loom/lwwregister.ex
+++ b/lib/loom/lwwregister.ex
@@ -38,7 +38,7 @@ defmodule Loom.LWWRegister do
 
   """
   @spec new(term) :: t
-  def new(value), do: new |> set(value)
+  def new(value), do: new() |> set(value)
 
   @doc """
   Returns a new LWWRegister CRDT. Initializes to `value` with another clock
@@ -48,7 +48,7 @@ defmodule Loom.LWWRegister do
 
   """
   @spec new(term, pos_integer) :: t
-  def new(value, clock), do: new |> set(value, clock)
+  def new(value, clock), do: new() |> set(value, clock)
 
 
   @doc """
@@ -62,7 +62,7 @@ defmodule Loom.LWWRegister do
 
   """
   @spec set(t, term) :: t
-  def set(reg, value), do: set(reg, value, make_microtime)
+  def set(reg, value), do: set(reg, value, make_microtime())
 
   @doc """
   Set a value according to your own clock.

--- a/lib/loom/pncounter.ex
+++ b/lib/loom/pncounter.ex
@@ -1,7 +1,7 @@
 defmodule Loom.PNCounter do
   @moduledoc """
   Positive-negative counters
-  
+
   PNCounters are counters that are capable of incrementing and decrementing.
   They are useful for like counters, where a user may like and then unlike
   something in succession.
@@ -55,8 +55,8 @@ defmodule Loom.PNCounter do
     end
     {p, n} = Enum.reduce(values, {%{},%{}}, fn {actor, {inc,dec}}, {p, n} ->
                 {
-                  (if inc, do: Dict.put(p, actor, inc), else: p),
-                  (if dec, do: Dict.put(n, actor, dec), else: n)
+                  (if inc, do: Map.put(p, actor, inc), else: p),
+                  (if dec, do: Map.put(n, actor, dec), else: n)
                 }
               end)
     %Counter{p: p, n: n}
@@ -106,7 +106,7 @@ defmodule Loom.PNCounter do
   """
   @spec value(t) :: integer
   def value(%Counter{p: p, n: n}) do
-    (Dict.values(p) |> Enum.sum) - (Dict.values(n) |> Enum.sum)
+    (Map.values(p) |> Enum.sum) - (Map.values(n) |> Enum.sum)
   end
 
   @doc """
@@ -122,8 +122,8 @@ defmodule Loom.PNCounter do
   @spec join(t, t) :: t
   def join(%Counter{p: p1, n: n1}, %Counter{p: p2, n: n2}) do
     %Counter{
-      p: Dict.merge(p1, p2, fn (_,v1,v2) -> max(v1,v2) end),
-      n: Dict.merge(n1, n2, fn (_,v1,v2) -> max(v1,v2) end)
+      p: Map.merge(p1, p2, fn (_,v1,v2) -> max(v1,v2) end),
+      n: Map.merge(n1, n2, fn (_,v1,v2) -> max(v1,v2) end)
     }
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,10 +4,10 @@ defmodule Loom.Mixfile do
   def project do
     [app: :loom,
      description: "A modern CRDT library that uses protocols to create composable CRDTs.",
-     package: package,
+     package: package(),
      version: "0.1.0-dev",
      elixir: "~> 1.0",
-     deps: deps,
+     deps: deps(),
      test_coverage: [tool: ExCoveralls],
     #  docs: [readme: true, main: "README"]
     ]

--- a/test/loom_gcounter_test.exs
+++ b/test/loom_gcounter_test.exs
@@ -21,8 +21,8 @@ defmodule LoomGcounterTest do
   #     IO.inspect {:call, :inc, [actor, int]}
   #     IO.inspect val[actor]
   #     val
-  #     |> Dict.put(:flat, f+int)
-  #     |> Dict.put(actor, Counter.inc(val[actor], actor, int))
+  #     |> Map.put(:flat, f+int)
+  #     |> Map.put(actor, Counter.inc(val[actor], actor, int))
   #   end
   #
   #   def precondition(val, {:call, _, :inc, [_, _]}) do


### PR DESCRIPTION
I fixed warnings on compile time for latest Elixir:
- Dict is deprecated switched to Map;
- added () to functions calls.